### PR TITLE
fix: create Telescope tables and schedule prune

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,7 +24,8 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        // Keep a generous Telescope history (30 days), pruning only older entries.
+        $schedule->command('telescope:prune --hours=720')->daily();
     }
 
     /**

--- a/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
+++ b/database/migrations/2018_08_08_100000_create_telescope_entries_table.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Get the migration connection name.
+     */
+    public function getConnection(): ?string
+    {
+        return config('telescope.storage.database.connection');
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->create('telescope_entries', function (Blueprint $table) {
+            $table->bigIncrements('sequence');
+            $table->uuid('uuid');
+            $table->uuid('batch_id');
+            $table->string('family_hash')->nullable();
+            $table->boolean('should_display_on_index')->default(true);
+            $table->string('type', 20);
+            $table->longText('content');
+            $table->dateTime('created_at')->nullable();
+
+            $table->unique('uuid');
+            $table->index('batch_id');
+            $table->index('family_hash');
+            $table->index('created_at');
+            $table->index(['type', 'should_display_on_index']);
+        });
+
+        $schema->create('telescope_entries_tags', function (Blueprint $table) {
+            $table->uuid('entry_uuid');
+            $table->string('tag');
+
+            $table->primary(['entry_uuid', 'tag']);
+            $table->index('tag');
+
+            $table->foreign('entry_uuid')
+                ->references('uuid')
+                ->on('telescope_entries')
+                ->cascadeOnDelete();
+        });
+
+        $schema->create('telescope_monitoring', function (Blueprint $table) {
+            $table->string('tag')->primary();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $schema = Schema::connection($this->getConnection());
+
+        $schema->dropIfExists('telescope_entries_tags');
+        $schema->dropIfExists('telescope_entries');
+        $schema->dropIfExists('telescope_monitoring');
+    }
+};


### PR DESCRIPTION
## Summary

Telescope's database tables were never created in this project, so **every request** failed its `insert into telescope_entries` and dumped a full stack trace into `storage/logs/laravel-*.log` — flooding and bloating the log.

## Fix

- **Publish the Telescope migration** (`2018_08_08_100000_create_telescope_entries_table`) so `telescope_entries`, `telescope_entries_tags`, and `telescope_monitoring` exist. This stops the missing-table errors.
- **Schedule `telescope:prune`** daily with a **30-day retention** (`--hours=720`) so the `telescope_entries` table self-cleans without throwing away recent history.

## Verification

- Ran the migration locally → tables created.
- Truncated the bloated log, then hit `/` and `/login` → **no new errors**, log stays empty.

> Note: the scheduler must be running (`php artisan schedule:run` via cron) for the prune to fire. No app behavior changes otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
