### PR TITLE
fix: revoke Passport tokens on logout

### DIFF
--- a/app/Http/Controllers/LoginController.php
+++ b/app/Http/Controllers/LoginController.php
@@ -35,6 +35,7 @@ class LoginController extends Controller
     public function home(Request $request)
     {
         $allParams = $request->all();
+
         $request->session()->flash('client', $allParams);
 
         $params = http_build_query($allParams);
@@ -96,11 +97,18 @@ class LoginController extends Controller
     /**
      * Logout current user.
      *
+     * @param  Request  $request
      * @return \Illuminate\Contracts\Foundation\Application|\Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function logout()
+    public function logout(Request $request)
     {
+        // Revoke the user's Passport access tokens so API sessions die with the web session.
+        Auth::user()?->tokens->each->revoke();
+
         Auth::logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
 
         return redirect('/');
     }

--- a/tests/Feature/LoginTest.php
+++ b/tests/Feature/LoginTest.php
@@ -76,4 +76,23 @@ class LoginTest extends TestCase
         $response = $this->get(route('login.callback', ['provider' => 'github']));
         $response->assertRedirect();
     }
+
+    /**
+     * Test logout revokes the user's access tokens.
+     *
+     * @return void
+     */
+    public function testLoginControllerLogoutMethod()
+    {
+        $user = User::factory()->create();
+        $user->createToken('Test Token');
+
+        $this->assertFalse($user->tokens()->where('revoked', true)->exists());
+
+        $response = $this->actingAs($user)->post(route('logout'));
+
+        $response->assertRedirect('/');
+        $this->assertGuest();
+        $this->assertTrue($user->tokens()->where('revoked', false)->doesntExist());
+    }
 }


### PR DESCRIPTION
## Summary

Resolves the `// @todo kill the token` in `LoginController::logout()`.

Logout previously only dropped the web auth guard, leaving the user's Passport access tokens valid. It now:
- revokes all of the user's Passport access tokens, and
- invalidates + regenerates the session (standard secure logout).

So API access dies together with the web session.

> The trailing-slash / `redirect_uri` concern is **out of scope** here — that's a backend routing issue (the slash ends up in the Vue component), not something to patch by string-trimming in the controller. Left for a separate change.

## Testing

- Added `testLoginControllerLogoutMethod`: creates a user + token, posts to `/logout`, asserts redirect to `/`, guest state, and that no un-revoked tokens remain.
- Full suite: **OK (33 tests, 86 assertions)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
