### PR TITLE
fix: avoid deprecated PDO::MYSQL_ATTR_SSL_CA on PHP 8.5

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -59,7 +59,9 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                // PDO::MYSQL_ATTR_SSL_CA is deprecated in PHP 8.5; prefer the
+                // Pdo\Mysql::ATTR_SSL_CA constant when the runtime provides it.
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 


### PR DESCRIPTION
## Summary

On PHP 8.5, `config/database.php` emits:

```
Deprecated: Constant PDO::MYSQL_ATTR_SSL_CA is deprecated since 8.5,
use Pdo\Mysql::ATTR_SSL_CA instead
```

The replacement `Pdo\Mysql::ATTR_SSL_CA` only exists on PHP 8.5+, while this project targets PHP 8.3 (Composer + CI). A plain swap would fatal on 8.3.

## Fix

Select the constant at runtime:

```php
(defined('Pdo\Mysql::ATTR_SSL_CA') ? Pdo\Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA)
```

- `defined()` itself does **not** trigger the deprecation, and the old constant is never evaluated on 8.5 → warning gone.
- On 8.3/8.4 the new class constant is absent, so it falls back to `PDO::MYSQL_ATTR_SSL_CA` (not deprecated there).
- Both names are a true alias (same attribute id per build), so behaviour is identical.

## Verification

- **PHP 8.5.3:** Laravel boots and reads `database.connections.mysql.options` with no deprecation notice.
- **PHP 8.3.31:** boots clean, constant resolves via `PDO::`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
